### PR TITLE
Don't commit on master!

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+current_branch = `git rev-parse --abbrev-ref HEAD`.strip
+
+raise RuntimeError.new("Don't commit on master!") if current_branch == 'master'


### PR DESCRIPTION
Prevents accidentally committing without checking out a feature branch.